### PR TITLE
Adds a "This project in early development" warning to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A straight-forward command-line interface (CLI) tool to showcase how to perform basic Entropy actions.
 
-> This tool is early development. As such, a lot of things do not work. Feel free to play around with it and report any issues at [github.com/entropyxyz/cli](https://github.com/entropyxyz/sdk).
+> This tool is early development. As such, a lot of things do not work. Feel free to play around with it and report any issues at [github.com/entropyxyz/cli](https://github.com/entropyxyz/cli).
 
 ## Build and run
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Entropy CLI
 
-### Disclaimer: CLI currently in Alpha Stage, expect breaking changes
-
 A straight-forward command-line interface (CLI) tool to showcase how to perform basic Entropy actions.
+
+> This tool is early development. As such, a lot of things do not work. Feel free to play around with it and report any issues at [github.com/entropyxyz/cli](https://github.com/entropyxyz/sdk).
 
 ## Build and run
 


### PR DESCRIPTION
Addresses https://github.com/entropyxyz/entropy-docs/issues/90. Adds a simple callout to the top of the README:

> This tool is early development. As such, a lot of things do not work. Feel free to play around with it and report any issues at [github.com/entropyxyz/cli](https://github.com/entropyxyz/cli).