### PR TITLE
remove @ts-ignore for @entropyxyz/sdk

### DIFF
--- a/src/common/initializeEntropy.ts
+++ b/src/common/initializeEntropy.ts
@@ -1,6 +1,4 @@
 import Entropy, { wasmGlobalsReady } from "@entropyxyz/sdk"
-// TODO: fix importing of types from @entropy/sdk/keys
-// @ts-ignore
 import Keyring from "@entropyxyz/sdk/keys"
 import inquirer from "inquirer"
 import { decrypt, encrypt } from "../flows/password"

--- a/src/flows/entropyTransfer/types.ts
+++ b/src/flows/entropyTransfer/types.ts
@@ -1,5 +1,5 @@
-// @ts-ignore
 import { Pair } from '@entropyxyz/sdk/keys'
+
 export interface TransferOptions { 
   from: Pair
   to: string

--- a/tests/testing-utils/index.ts
+++ b/tests/testing-utils/index.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import { spinNetworkUp, spinNetworkDown, } from "@entropyxyz/sdk/testing"
 import * as readline from 'readline'
 import { randomBytes } from 'crypto'

--- a/tests/testing-utils/setup-test.ts
+++ b/tests/testing-utils/setup-test.ts
@@ -1,8 +1,6 @@
 import { Test } from 'tape'
 import { Entropy, wasmGlobalsReady } from '@entropyxyz/sdk'
-// @ts-ignore
 import { spinNetworkUp, spinNetworkDown, } from "@entropyxyz/sdk/testing"
-// @ts-ignore
 import Keyring from '@entropyxyz/sdk/keys'
 
 import { initializeEntropy } from '../../src/common/initializeEntropy'

--- a/tests/transfer.test.ts
+++ b/tests/transfer.test.ts
@@ -1,7 +1,5 @@
 import test from 'tape'
 import { wasmGlobalsReady } from '@entropyxyz/sdk'
-// WIP: I'm seeing problems importing this?
-// @ts-ignore
 import Keyring from '@entropyxyz/sdk/keys'
 import { 
   makeSeed,


### PR DESCRIPTION
Re: https://github.com/entropyxyz/cli/issues/158

We have a bunch of `@ts-ignore` because importing types from `@entropyxyz/sdk` is not working as we'd like.