### PR TITLE
remove "sleep" calls as SDK utils handle those

### DIFF
--- a/tests/manage-accounts.test.ts
+++ b/tests/manage-accounts.test.ts
@@ -1,12 +1,10 @@
+import test from 'tape'
 import { wasmGlobalsReady } from '@entropyxyz/sdk'
 // @ts-ignore
 import { isValidSubstrateAddress } from '@entropyxyz/sdk/utils'
 // @ts-ignore
 import Keyring from '@entropyxyz/sdk/keys'
 import { randomAsHex } from '@polkadot/util-crypto'
-import test from 'tape'
-// @ts-ignore
-import { spinNetworkUp, spinNetworkDown, } from "@entropyxyz/sdk/testing"
 import { EntropyAccountConfig, EntropyConfig } from '../src/config/types'
 import { listAccounts } from '../src/flows/manage-accounts/list'
 import { createAccount } from '../src/flows/manage-accounts/helpers/create-account'

--- a/tests/testing-utils/setup-test.ts
+++ b/tests/testing-utils/setup-test.ts
@@ -7,7 +7,7 @@ import Keyring from '@entropyxyz/sdk/keys'
 
 import { initializeEntropy } from '../../src/common/initializeEntropy'
 import * as config from '../../src/config'
-import { makeSeed, promiseRunner, sleep } from './'
+import { makeSeed, promiseRunner } from './'
 
 interface SetupTestOpts {
   configPath?: string
@@ -38,8 +38,6 @@ export async function setupTest (t: Test, opts?: SetupTestOpts): Promise<{ entro
 
   await run('config.init', config.init(configPath))
 
-  // TODO: remove this after new SDK is published
-  await sleep(process.env.GITHUB_WORKSPACE ? 30_000 : 5_000)
   // To follow the same way we initiate entropy within the cli we must go through the same process of creating an initial keyring
   // as done in src/flows/manage-accounts/new-key.ts
   const keyring = new Keyring({ seed, debug: true })

--- a/tests/transfer.test.ts
+++ b/tests/transfer.test.ts
@@ -6,7 +6,6 @@ import Keyring from '@entropyxyz/sdk/keys'
 import { 
   makeSeed,
   promiseRunner,
-  sleep,
   spinNetworkUp,
   spinNetworkDown
 } from './testing-utils'
@@ -31,7 +30,6 @@ test('Transfer', async (t) => {
       console.error('Error while spinning network down', error.message)
     )
   })
-  await sleep(process.env.GITHUB_WORKSPACE ? 30_000 : 5_000)
 
   const naynaySeed = makeSeed()
   const naynayKeyring = new Keyring({ seed: naynaySeed, debug: true })


### PR DESCRIPTION
remove un-needed sleep commands (SDK is smarter with its spinUpNetwork tool)