### PR TITLE
get all config.get* methods fail safely

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -83,6 +83,7 @@ function makeGetErrorHandler (configPath) {
     if (err.code !== 'ENOENT') throw err
 
     const newConfig = migrateData(allMigrations, {})
+    mkdirp.sync(dirname(configPath))
     writeFileSync(configPath, serialize(newConfig))
     return newConfig
   }


### PR DESCRIPTION
I noticed that there was a nice error-handler for `getSync` but not for `get`!

Consolidated!