### PR TITLE
refactor entropy register so CLI/TUI are similar

### DIFF
--- a/src/account/interaction.ts
+++ b/src/account/interaction.ts
@@ -2,7 +2,7 @@ import inquirer from "inquirer";
 import Entropy from "@entropyxyz/sdk";
 
 import { EntropyAccount } from './main'
-import { selectAndPersistNewAccount } from "./utils";
+import { selectAndPersistNewAccount, addVerifyingKeyToAccountAndSelect } from "./utils";
 import { findAccountByAddressOrName, print } from "../common/utils"
 import { EntropyConfig } from "../config/types";
 import * as config from "../config";
@@ -77,16 +77,15 @@ export async function entropyRegister (entropy: Entropy, endpoint: string, store
   const accountService = new EntropyAccount(entropy, endpoint)
 
   const { accounts, selectedAccount } = storedConfig
-  const currentAccount = findAccountByAddressOrName(accounts, selectedAccount)
-  if (!currentAccount) {
+  const account = findAccountByAddressOrName(accounts, selectedAccount)
+  if (!account) {
     print("No account selected to register")
-    return;
+    return
   }
-  print("Attempting to register the address:", currentAccount.address)
-  const updatedAccount = await accountService.registerAccount(currentAccount)
-  const arrIdx = accounts.indexOf(currentAccount)
-  accounts.splice(arrIdx, 1, updatedAccount)
-  print("Your address", updatedAccount.address, "has been successfully registered.")
 
-  return { accounts, selectedAccount }
+  print("Attempting to register the address:", account.address)
+  const verifyingKey = await accountService.register()
+  await addVerifyingKeyToAccountAndSelect(verifyingKey, account.address)
+
+  print("Your address", account.address, "has been successfully registered.")
 }

--- a/src/account/main.ts
+++ b/src/account/main.ts
@@ -66,6 +66,7 @@ export class EntropyAccount extends EntropyBase {
       }
       : undefined
 
+    this.logger.debug(`registering with params: ${registerParams}`, 'REGISTER')
     return this.entropy.register(registerParams)
       // NOTE: if "register" fails for any reason, core currently leaves the chain in a "polluted"
       // state. To fix this we manually "prune" the dirty registration transaction.
@@ -73,28 +74,6 @@ export class EntropyAccount extends EntropyBase {
         await this.pruneRegistration()
         throw error
       })
-  }
-
-  // WATCH: should this be extracted to interaction.ts?
-  async registerAccount (account: EntropyAccountConfig, registerParams?: AccountRegisterParams): Promise<EntropyAccountConfig> {
-    this.logger.debug(
-      [
-        `registering account: ${account.address}`,
-        // @ts-expect-error Type export of ChildKey still not available from SDK
-        `to keyring: ${this.entropy.keyring.getLazyLoadAccountProxy('registration').pair.address}`
-      ].join(', '),
-      'REGISTER'
-    )
-    // Register params to be defined from user input (arguments/options or inquirer prompts)
-    try {
-      const verifyingKey = await this.register(registerParams)
-      // NOTE: this mutation triggers events in Keyring
-      account.data.registration.verifyingKeys.push(verifyingKey)
-      return account
-    } catch (error) {
-      this.logger.error('There was a problem registering', error)
-      throw error
-    }
   }
 
   /* PRIVATE */

--- a/src/account/utils.ts
+++ b/src/account/utils.ts
@@ -26,6 +26,8 @@ export async function selectAndPersistNewAccount (newAccount: EntropyAccountConf
 export async function addVerifyingKeyToAccountAndSelect (verifyingKey: string, accountNameOrAddress: string) {
   const storedConfig = await config.get()
   const account = findAccountByAddressOrName(storedConfig.accounts, accountNameOrAddress)
+  if (!account) throw Error(`Unable to persist verifyingKey "${verifyingKey}" to unknown account "${accountNameOrAddress}"`)
+
   account.data.registration.verifyingKeys.push(verifyingKey)
 
   // persist to config, set selectedAccount

--- a/src/account/utils.ts
+++ b/src/account/utils.ts
@@ -1,9 +1,9 @@
+import { ACCOUNTS_CONTENT } from './constants';
 import { EntropyAccountConfig } from "../config/types";
 import * as config from "../config";
-import { ACCOUNTS_CONTENT } from './constants';
-import { generateAccountChoices } from '../common/utils';
+import { generateAccountChoices, findAccountByAddressOrName } from '../common/utils';
 
-export async function selectAndPersistNewAccount (newAccount) {
+export async function selectAndPersistNewAccount (newAccount: EntropyAccountConfig) {
   const storedConfig = await config.get()
   const { accounts } = storedConfig
 
@@ -19,8 +19,19 @@ export async function selectAndPersistNewAccount (newAccount) {
   accounts.push(newAccount) 
   await config.set({
     ...storedConfig,
-    accounts,
     selectedAccount: newAccount.address
+  })
+}
+
+export async function addVerifyingKeyToAccountAndSelect (verifyingKey: string, accountNameOrAddress: string) {
+  const storedConfig = await config.get()
+  const account = findAccountByAddressOrName(storedConfig.accounts, accountNameOrAddress)
+  account.data.registration.verifyingKeys.push(verifyingKey)
+
+  // persist to config, set selectedAccount
+  await config.set({
+    ...storedConfig,
+    selectedAccount: account.address
   })
 }
 


### PR DESCRIPTION
During QA discussion, notice that entropy register was coded the same in CLI + TUI.

This PR:
- reduces what `main` does to only be registering on-chain
- moves entropy config mutation + persistence into `util`
- changes `command` and `interaction` to use the same 2 functions
  - includes refactor of the `command` action