### PR TITLE
[NayNay] Signing error messaging

### DIFF
--- a/src/sign/interaction.ts
+++ b/src/sign/interaction.ts
@@ -24,11 +24,20 @@ export async function entropySign (entropy: Entropy, endpoint: string) {
   //   return
   // }
   // case 'Sign With Adapter': {
-  const { msg } = await getMsgFromUser(inquirer)
-  const { signature, verifyingKey } = await signingService.signMessageWithAdapters({ msg })
-  print('msg to be signed:', msg)
-  print('verifying key:', verifyingKey)
-  print('signature:', signature)
+  try {
+    const { msg } = await getMsgFromUser(inquirer)
+    const { signature, verifyingKey } = await signingService.signMessageWithAdapters({ msg })
+    print('msg to be signed:', msg)
+    print('verifying key:', verifyingKey)
+    print('signature:', signature)
+    return
+  } catch (error) {
+    if (!entropy.signingManager.verifyingKey) {
+      console.error('Please register your Entropy account before signing');
+      return 'exit'
+    }
+    throw error
+  }
   //  return
   // }
   // case 'Exit to Main Menu': 

--- a/tests/sign.test.ts
+++ b/tests/sign.test.ts
@@ -20,3 +20,18 @@ test('Sign - signMessageWithAdapters', async (t) => {
   t.end()
 })
 
+test('Sign - signMessageWithAdapters without verifying key', async (t) => {
+  const { entropy } = await setupTest(t)
+  const signService = new EntropySign(entropy, endpoint)
+
+  // should fail and return exi
+  await signService.signMessageWithAdapters({ msg: "heyo!" })
+    .then(() => t.fail('Signing should fail, user has not registered yet'))
+    .catch((err) => {
+      t.match(err.toString(), /TypeError/, 'Sign failed, user needs to register first')
+      return
+    })
+
+  t.end()
+})
+

--- a/tests/sign.test.ts
+++ b/tests/sign.test.ts
@@ -20,15 +20,15 @@ test('Sign - signMessageWithAdapters', async (t) => {
   t.end()
 })
 
-test('Sign - signMessageWithAdapters without verifying key', async (t) => {
+test('Sign - signMessageWithAdapters (no verifying key)', async (t) => {
   const { entropy } = await setupTest(t)
   const signService = new EntropySign(entropy, endpoint)
 
-  // should fail and return exi
+  const description = 'Unregistered user gets error when they try to sign.'
   await signService.signMessageWithAdapters({ msg: "heyo!" })
-    .then(() => t.fail('Signing should fail, user has not registered yet'))
+    .then(() => t.fail(description))
     .catch((err) => {
-      t.match(err.toString(), /TypeError/, 'Sign failed, user needs to register first')
+      t.match(err.message, /Cannot read properties of undefined/, description)
       return
     })
 


### PR DESCRIPTION
<!-- Provide a brief description of the changes made in this PR -->

## Related Issue(s)
<!-- Link to the issue(s) that this PR addresses -->

- Resolves #222 

## Proposed Changes
<!-- List the changes made in this PR -->

- updated signing error handling to return human readbale message when user tries to sign without registering first

## Testing
<!-- Describe how you tested the changes -->

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Screenshots (if applicable)
<!-- Include any relevant screenshots here -->

## Additional Context
<!-- Add any other context or information that might be helpful for the reviewer -->

## Checklist
<!-- Confirm that the following items are true and correct: -->

- [x] I have performed a self-review of my code.
- [x] I have added tests.
- [x] I have commented my code.
- [ ] I have included a `CHANGELOG.md` entry.
- [ ] I have updated documentation in `github.com:entropyxyz/entropy-docs`, where necessary.

