### PR TITLE
Mixmix/refactor scripts

### DIFF
--- a/dev/bin/test-ts.sh
+++ b/dev/bin/test-ts.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # HACK: normally we could just go:
-#   tape tests/*.test.ts | tap-spec
+#   tape tests/*.test.ts
 #
 # but here we are fighting TS ... this works well enough
 
@@ -12,13 +12,13 @@ if [ $ONLY_FILES ]; then
   # NOTE: `yarn test:only` ensures our CI fails if those are left in
   set -e;
   for t in $ONLY_FILES; do
-    npx tsx $t | tap-spec;
+    npx tsx $t;
   done
 else
   # Otherwise run all tests
   set -e;
   for t in tests/*.test.ts; do
-    npx tsx $t | tap-spec;
+    npx tsx $t;
   done
 fi
 

--- a/package.json
+++ b/package.json
@@ -9,19 +9,22 @@
     "build": "./dev/bin/build.sh",
     "build:global": "yarn build && npm install -g",
     "lint": "eslint . --ext .ts --fix",
-    "test": "yarn test:types && yarn build:global && yarn test:hosts && yarn test:network:up && yarn test:ts && yarn test:network:down && yarn test:only",
+    "test": "yarn test:types && yarn test:global && yarn test:ts:full && yarn test:only",
+    "test:global": "yarn build:global && node tests/global.test.mjs | tap-spec",
     "test:hosts": "./dev/bin/test-hosts.sh",
     "test:only": "./dev/bin/test-only.sh",
-    "test:ts": "./dev/bin/test-ts.sh",
+    "test:ts": "./dev/bin/test-ts.sh | tap-spec",
+    "test:ts:full": "yarn test:hosts && yarn test:network:reset && yarn test:ts && yarn test:network:down",
     "test:types": "tsc --project tsconfig.json",
     "test:network:up": "node tests/testing-utils/test-network.mjs up",
     "test:network:down": "node tests/testing-utils/test-network.mjs down",
+    "test:network:reset": "yarn test:network:down && yarn test:network:up",
     "prepare": "husky",
     "prepack": "pinst --disable",
     "postpack": "pinst --enable",
-    "link:sdk": "yarn link @entropyxyz/sdk",
-    "unlink:sdk": "yarn unlink @entropyxyz/sdk",
-    "re-link:sdk": "yarn unlink:sdk && yarn link:sdk"
+    "sdk:link": "yarn link @entropyxyz/sdk",
+    "sdk:unlink": "yarn unlink @entropyxyz/sdk",
+    "sdk:relink": "yarn sdk:unlink && yarn sdk:link"
   },
   "files": [
     "dist"

--- a/tests/global.test.mjs
+++ b/tests/global.test.mjs
@@ -1,9 +1,7 @@
 import test from 'tape'
 
-import {
-  promiseRunner,
-  execPromise
-} from './testing-utils'
+import { promiseRunner } from './testing-utils/promise-runner.mjs'
+import { execPromise } from './testing-utils/exec-promise.mjs'
 
 test('Global: entropy --help', async (t) => {
   /* Setup */

--- a/tests/testing-utils/exec-promise.mjs
+++ b/tests/testing-utils/exec-promise.mjs
@@ -1,0 +1,16 @@
+import { exec } from 'node:child_process'
+
+/* Promise wrapper function of [exec](https://nodejs.org/api/child_process.html#child_processexeccommand-options-callback)
+ *
+ * @param {string} command - a string command to run in child process
+ */
+
+export function execPromise (command) {
+  return new Promise((res, rej) => {
+    exec(command, (error, stdout, stderr) => {
+      if (!error && !stderr) res(stdout)
+      else if (!!stderr && !error) rej(stderr)
+      else if (!!error) rej(error)
+    })
+  })
+}

--- a/tests/testing-utils/index.ts
+++ b/tests/testing-utils/index.ts
@@ -1,8 +1,6 @@
-import { exec } from 'node:child_process'
 // @ts-ignore
 import { spinNetworkUp, spinNetworkDown, } from "@entropyxyz/sdk/testing"
 import * as readline from 'readline'
-import { randomBytes } from 'crypto'
 
 export {
   spinNetworkUp,
@@ -10,63 +8,14 @@ export {
 }
 
 export * from './constants.mjs'
+export * from './promise-runner.mjs'
+export * from './exec-promise.mjs'
 export * from './setup-test'
-
-/* Promise wrapper function of [exec](https://nodejs.org/api/child_process.html#child_processexeccommand-options-callback)
- *
- * @param {string} command - a string command to run in child process
- */
-
-export function execPromise (command: string): Promise<any> {
-  return new Promise((res, rej) => {
-    exec(command, (error, stdout, stderr) => {
-      if (!error && !stderr) res(stdout)
-      else if (!!stderr && !error) rej(stderr)
-      else if (!!error) rej(error)
-    })
-  })
-}
-
-/* Helper for wrapping promises which makes it super clear in logging if the promise
- * resolves or threw.
- *
- * @param {any} t - an instance to tape runner
- * @param {boolean} keepThrowing - toggle throwing
- */
-export function promiseRunner(t: any, keepThrowing = false) {
-  // NOTE: this function swallows errors
-  return async function run(
-    message: string,
-    promise: Promise<any>
-  ): Promise<any> {
-    if (promise.constructor !== Promise) {
-      t.pass(message)
-      return Promise.resolve(promise)
-    }
-
-    const startTime = Date.now()
-    return promise
-      .then((result) => {
-        const time = (Date.now() - startTime) / 1000
-        const noPad = message.length > 40
-        const pad = noPad ? '' : Array(40 - message.length)
-          .fill('-')
-          .join('')
-        t.pass(`${message} ${pad} ${time}s`)
-        return result
-      })
-      .catch((err) => {
-        console.log('error', err);
-        t.error(err, message)
-        if (keepThrowing) throw err
-      })
-  }
-}
 
 const SLEEP_DONE = '▓'
 const SLEEP_TODO = '░'
 
-export function sleep(durationInMs: number) {
+export function sleep (durationInMs: number) {
   return new Promise((resolve) => {
     let count = 0
 
@@ -109,6 +58,3 @@ function undoLastLine() {
   readline.cursorTo(process.stdout, 4) // indent
 }
 
-export function makeSeed () {
-  return '0x' + randomBytes(32).toString('hex')
-}

--- a/tests/testing-utils/promise-runner.mjs
+++ b/tests/testing-utils/promise-runner.mjs
@@ -1,0 +1,39 @@
+
+/* Helper for wrapping promises which makes it super clear in logging if the promise
+ * resolves or threw.
+ *
+ * @param {any} t - an instance to tape runner
+ * @param {boolean} keepThrowing - toggle throwing
+ */
+export function promiseRunner(t, keepThrowing = false) {
+  // NOTE: this function swallows errors
+
+  /* 
+   * @param {string} message - message to post with pass/ fail
+   * @param {promise} promise - some promise to handle running
+   */
+  return async function run(message, promise) {
+    if (promise.constructor !== Promise) {
+      t.pass(message)
+      return Promise.resolve(promise)
+    }
+
+    const startTime = Date.now()
+    return promise
+      .then((result) => {
+        const time = (Date.now() - startTime) / 1000
+        const noPad = message.length > 40
+        const pad = noPad ? '' : Array(40 - message.length)
+          .fill('-')
+          .join('')
+        t.pass(`${message} ${pad} ${time}s`)
+        return result
+      })
+      .catch((err) => {
+        console.log('error', err);
+        t.error(err, message)
+        if (keepThrowing) throw err
+      })
+  }
+}
+

--- a/tests/testing-utils/setup-test.ts
+++ b/tests/testing-utils/setup-test.ts
@@ -4,10 +4,11 @@ import { Entropy, wasmGlobalsReady } from '@entropyxyz/sdk'
 import Keyring from '@entropyxyz/sdk/keys'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { randomBytes } from 'node:crypto'
 
 import { initializeEntropy } from '../../src/common/initializeEntropy'
 import * as config from '../../src/config'
-import { makeSeed, promiseRunner } from './'
+import { promiseRunner } from './'
 
 interface SetupTestOpts {
   configPath?: string
@@ -52,4 +53,8 @@ export async function setupTest (t: Test, opts?: SetupTestOpts): Promise<{ entro
   })
 
   return { entropy, run, endpoint }
+}
+
+function makeSeed () {
+  return '0x' + randomBytes(32).toString('hex')
 }

--- a/tests/testing-utils/setup-test.ts
+++ b/tests/testing-utils/setup-test.ts
@@ -2,9 +2,9 @@ import { Test } from 'tape'
 import { Entropy, wasmGlobalsReady } from '@entropyxyz/sdk'
 // @ts-ignore
 import Keyring from '@entropyxyz/sdk/keys'
+import { randomAsHex } from '@polkadot/util-crypto'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { randomBytes } from 'node:crypto'
 
 import { initializeEntropy } from '../../src/common/initializeEntropy'
 import * as config from '../../src/config'
@@ -27,7 +27,7 @@ function uniqueConfigPath () {
 export async function setupTest (t: Test, opts?: SetupTestOpts): Promise<{ entropy: Entropy; run: any; endpoint: string }> {
   const {
     configPath = uniqueConfigPath(),
-    seed = makeSeed(),
+    seed = randomAsHex(32),
     endpoint = 'ws://127.0.0.1:9944',
   } = opts || {}
 
@@ -53,8 +53,4 @@ export async function setupTest (t: Test, opts?: SetupTestOpts): Promise<{ entro
   })
 
   return { entropy, run, endpoint }
-}
-
-function makeSeed () {
-  return '0x' + randomBytes(32).toString('hex')
 }


### PR DESCRIPTION
**Problems**:
- :fire: `yarn test` doesn't currently reset the network before running tests => failures because tests assume unique program hashes (that have not been deployed already)
- :cry: the `package.json` script `yarn test` is a mess

**I've refactored the tests to:**
- [x] collected all the "ts" related test-steps into `test:ts:full`
- [x] separate out the "global" testing into `test:global`
  - rename: `test/global.test.ts` => `test/global.test.mjs` (no need to depend on building `tsx`)
  - required making some `testing-utils` into `.mjs` files
- [x] added `network:reset` script
- [x] moved `tap-spec` to be in the `package.json` only, making it easier to rip out / turn off / swap out / maintain
