### PR TITLE
mixmix/config-types

### DIFF
--- a/src/account/main.ts
+++ b/src/account/main.ts
@@ -7,20 +7,20 @@ import { FLOW_CONTEXT } from "./constants";
 import { AccountCreateParams, AccountImportParams, AccountRegisterParams } from "./types";
 
 import { EntropyBase } from "../common/entropy-base";
-import { EntropyAccountConfig, EntropyAccountConfigFormatted } from "../config/types";
+import { EntropyConfigAccount, EntropyConfigAccountFormatted } from "../config/types";
 
 export class EntropyAccount extends EntropyBase {
   constructor (entropy: Entropy, endpoint: string) {
     super({ entropy, endpoint, flowContext: FLOW_CONTEXT })
   }
 
-  static async create ({ name, path }: AccountCreateParams): Promise<EntropyAccountConfig> {
+  static async create ({ name, path }: AccountCreateParams): Promise<EntropyConfigAccount> {
     const seed = randomAsHex(32)
     return EntropyAccount.import({ name, seed, path })
   }
 
   // WARNING: #create depends on #import => be careful modifying this function
-  static async import ({ name, seed, path }: AccountImportParams ): Promise<EntropyAccountConfig> {
+  static async import ({ name, seed, path }: AccountImportParams ): Promise<EntropyConfigAccount> {
     await wasmGlobalsReady()
     const keyring = new Keyring({ seed, path, debug: true })
 
@@ -40,13 +40,13 @@ export class EntropyAccount extends EntropyBase {
     }
   }
 
-  static list ({ accounts }: { accounts: EntropyAccountConfig[] }): EntropyAccountConfigFormatted[] {
+  static list ({ accounts }: { accounts: EntropyConfigAccount[] }): EntropyConfigAccountFormatted[] {
     if (!accounts.length)
       throw new Error(
         'AccountsError: There are currently no accounts available, please create or import a new account using the Manage Accounts feature'
       )
 
-    return accounts.map((account: EntropyAccountConfig) => ({
+    return accounts.map((account: EntropyConfigAccount) => ({
       name: account.name,
       address: account.address,
       verifyingKeys: account?.data?.registration?.verifyingKeys || []

--- a/src/account/utils.ts
+++ b/src/account/utils.ts
@@ -3,11 +3,11 @@ import { u8aToHex } from '@polkadot/util'
 // @ts-expect-error
 import { isValidSubstrateAddress } from '@entropyxyz/sdk/utils'
 import { ACCOUNTS_CONTENT } from './constants';
-import { EntropyAccountConfig } from "../config/types";
+import { EntropyConfigAccount } from "../config/types";
 import * as config from "../config";
 import { generateAccountChoices, findAccountByAddressOrName } from '../common/utils';
 
-export async function selectAndPersistNewAccount (newAccount: EntropyAccountConfig) {
+export async function selectAndPersistNewAccount (newAccount: EntropyConfigAccount) {
   const storedConfig = await config.get()
   const { accounts } = storedConfig
 
@@ -82,7 +82,7 @@ export const accountNewQuestions = [
   },
 ]
 
-export const accountSelectQuestions = (accounts: EntropyAccountConfig[]) => [{
+export const accountSelectQuestions = (accounts: EntropyConfigAccount[]) => [{
   type: 'list',
   name: ACCOUNTS_CONTENT.selectAccount.name,
   message: ACCOUNTS_CONTENT.selectAccount.message,
@@ -114,7 +114,7 @@ function getPublicKeyFromAddress (address: string) {
   return u8aToHex(publicKey);
 }
 
-export function generateAccountDataForPrint (newAccount: EntropyAccountConfig) {
+export function generateAccountDataForPrint (newAccount: EntropyConfigAccount) {
   const publicKey = getPublicKeyFromAddress(newAccount.address)
   const accountData = [
     { key: 'Secret seed:', value: newAccount.data.seed },

--- a/src/common/initializeEntropy.ts
+++ b/src/common/initializeEntropy.ts
@@ -3,7 +3,7 @@ import Entropy, { wasmGlobalsReady } from "@entropyxyz/sdk"
 // @ts-ignore
 import Keyring from "@entropyxyz/sdk/keys"
 import * as config from "../config"
-import { EntropyAccountData } from "../config/types"
+import { EntropyConfigAccountData } from "../config/types"
 import { EntropyLogger } from "./logger"
 
 // TODO: unused
@@ -28,7 +28,7 @@ interface InitializeEntropyOpts {
   endpoint: string,
   configPath?: string // for testing
 }
-type MaybeKeyMaterial = EntropyAccountData | string
+type MaybeKeyMaterial = EntropyConfigAccountData | string
 
 // WARNING: in programatic cli mode this function should NEVER prompt users
 
@@ -113,10 +113,10 @@ export const initializeEntropy = async ({ keyMaterial, endpoint, configPath }: I
 
 
 // NOTE: frankie this was prettier before I had to refactor it for merge conflicts, promise
-async function getAccountData (keyMaterial: MaybeKeyMaterial): Promise<{ accountData: EntropyAccountData }> {
+async function getAccountData (keyMaterial: MaybeKeyMaterial): Promise<{ accountData: EntropyConfigAccountData }> {
   if (isEntropyAccountData(keyMaterial)) {
     return { 
-      accountData: keyMaterial as EntropyAccountData
+      accountData: keyMaterial as EntropyConfigAccountData
     }
   }
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,6 +1,6 @@
 import { Entropy } from '@entropyxyz/sdk'
 import { Buffer } from 'buffer'
-import { EntropyAccountConfig } from "../config/types"
+import { EntropyConfigAccount } from "../config/types"
 import { EntropyLogger } from './logger'
 
 export function stripHexPrefix (str: string): string {
@@ -58,7 +58,7 @@ export function buf2hex (buffer: ArrayBuffer): string {
   return Buffer.from(buffer).toString("hex")
 }
 
-export function generateAccountChoices (accounts: EntropyAccountConfig[]) {
+export function generateAccountChoices (accounts: EntropyConfigAccount[]) {
   return accounts
     .map((account) => ({
       name: `${account.name} (${account.address})`,
@@ -66,12 +66,12 @@ export function generateAccountChoices (accounts: EntropyAccountConfig[]) {
     }))
 }
 
-export function accountChoicesWithOther (accounts: EntropyAccountConfig[]) {
+export function accountChoicesWithOther (accounts: EntropyConfigAccount[]) {
   return generateAccountChoices(accounts)
     .concat([{ name: "Other", value: null }])
 }
 
-export function findAccountByAddressOrName (accounts: EntropyAccountConfig[], aliasOrAddress: string) {
+export function findAccountByAddressOrName (accounts: EntropyConfigAccount[], aliasOrAddress: string) {
   if (!aliasOrAddress || !aliasOrAddress.length) throw Error('account name or address required')
 
   return (

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -6,7 +6,7 @@ import envPaths from 'env-paths'
 
 import allMigrations from './migrations'
 import { serialize, deserialize } from './encoding'
-import { EntropyConfig, EntropyAccountConfig } from './types'
+import { EntropyConfig, EntropyConfigAccount } from './types'
 
 const paths = envPaths('entropy-cryptography', { suffix: '' })
 const CONFIG_PATH = join(paths.config, 'entropy-cli.json')
@@ -74,7 +74,7 @@ export async function set (config: EntropyConfig, configPath = CONFIG_PATH) {
   await writeFile(configPath, serialize(config))
 }
 
-export async function setSelectedAccount (account: EntropyAccountConfig, configPath = CONFIG_PATH) {
+export async function setSelectedAccount (account: EntropyConfigAccount, configPath = CONFIG_PATH) {
   const storedConfig = await get(configPath)
 
   if (storedConfig.selectedAccount === account.name) return storedConfig

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,5 +1,5 @@
 export interface EntropyConfig {
-  accounts: EntropyAccountConfig[]
+  accounts: EntropyConfigAccount[]
   endpoints: {
     dev: string;
     'test-net': string
@@ -9,21 +9,21 @@ export interface EntropyConfig {
   'migration-version': string
 }
 
-export interface EntropyAccountConfig {
+export interface EntropyConfigAccount {
   name: string
   address: string
-  data: EntropyAccountData
+  data: EntropyConfigAccountData
 }
 
 // Safe output format
-export interface EntropyAccountConfigFormatted {
+export interface EntropyConfigAccountFormatted {
   name: string
   address: string
   verifyingKeys: string[]
 }
 
 // TODO: document this whole thing
-export interface EntropyAccountData {
+export interface EntropyConfigAccountData {
   debug?: boolean
   seed: string
   admin?: EntropyAccount

--- a/tests/account.test.ts
+++ b/tests/account.test.ts
@@ -9,13 +9,13 @@ import { randomAsHex } from '@polkadot/util-crypto'
 
 import { EntropyAccount } from '../src/account/main'
 import { EntropyTransfer } from '../src/transfer/main'
-import { EntropyAccountConfig, EntropyConfig } from '../src/config/types'
+import { EntropyConfigAccount, EntropyConfig } from '../src/config/types'
 import * as config from '../src/config'
 import { promiseRunner, setupTest } from './testing-utils'
 import { charlieStashAddress, charlieStashSeed, eveSeed } from './testing-utils/constants.mjs'
 
 test('Account - list', async t => {
-  const account: EntropyAccountConfig = {
+  const account: EntropyConfigAccount = {
     name: 'Test Config',
     address: charlieStashAddress,
     data: {


### PR DESCRIPTION
This is part of a PR chain:

**mixmix/config-types** → [mixmix/load-entropy](https://github.com/entropyxyz/cli/pull/309) → [mixmix/custom-config](https://github.com/entropyxyz/cli/pull/264)

---

rename the config types to be more consistent / predictable

data | type
---|---
`storedConfig` | `EntropyConfig`
`storedConfig.accounts[0]` |  `EntropyConfigAccount`
`storedConfig.accounts[0].data` | `EntropyConfigAccountData`
`prettyPrint(storedConfig.accounts[0])` | `EntropyConfigAccountFormatted`
